### PR TITLE
Port PoseEstimator and PhotonRunnable code from FRC 7028 to track field pos

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -9,6 +9,14 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Translation3d;
+import static edu.wpi.first.math.util.Units.degreesToRadians;
+import static edu.wpi.first.math.util.Units.inchesToMeters;
 
 
 /**
@@ -136,4 +144,30 @@ public final class Constants {
     public static final double ENCODER_ROT_STOW = 0; // TUNE THIS
     // public static final int ARM_PIVOT_ID = 24;
   }
+  public static class VisionConstants {
+    // VisionConstants from FRC-7028 PhotonVision code
+
+    /** Physical location of the apriltag camera on the robot, relative to the center of the robot. */
+    // center of robot 10" forward of center, 1" left of center and 12" up from center of robot
+    public static final Translation3d camera1Translation = new Translation3d(Units.inchesToMeters(10.0), 
+    Units.inchesToMeters(1.0), Units.inchesToMeters(12.));// Cam mounted facing forward
+    public static final Rotation3d camera1Rotation = new Rotation3d(0,0,0); // pointing forward
+    public static final Transform3d APRILTAG_CAMERA_TO_ROBOT =
+              new Transform3d(
+                      camera1Translation,
+                      camera1Rotation); // transform camera1 from center of robot
+  
+
+    public static final double FIELD_LENGTH_METERS = 16.54175;
+    public static final double FIELD_WIDTH_METERS = 8.0137;
+
+    // Pose on the opposite side of the field. Use with `relativeTo` to flip a pose to the opposite alliance
+    public static final Pose2d FLIPPING_POSE = new Pose2d(
+        new Translation2d(FIELD_LENGTH_METERS, FIELD_WIDTH_METERS),
+        new Rotation2d(Math.PI));
+
+    /** Minimum target ambiguity. Targets with higher ambiguity will be discarded */
+    public static final double APRILTAG_AMBIGUITY_THRESHOLD = 0.2;
+  }
+
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj.XboxController;
 // import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import frc.robot.commands.ArmMove;
 // import frc.robot.commands.ArmZero;
 import frc.robot.commands.IntakeMove;
@@ -27,6 +28,8 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import frc.robot.subsystems.PoseEstimatorSubsystem;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -37,6 +40,9 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
   public static final Drivetrain drivetrain = Drivetrain.getInstance();
+  private final PoseEstimatorSubsystem poseEstimator =
+      new PoseEstimatorSubsystem(drivetrain::getGyroscopeRotation, drivetrain::getModulePositions);
+ 
   //public static final Arm arm = Arm.getInstance();
   public static final Intake intake = new Intake();
   public static final Arm arm = new Arm();
@@ -91,6 +97,11 @@ public class RobotContainer {
     autoChooser.addOption("highNodeAndDrive", "highNodeAndDrive");    //()
     autoChooser.addOption("highNodeAndBalance", "highNodeAndBalance");//()
     autoChooser.addOption("TEST", "TEST");                            //()
+    /**** Vision tab ****/
+    final var visionTab = Shuffleboard.getTab("Vision");
+
+    // Pose estimation
+    poseEstimator.addDashboardWidgets(visionTab);
   }
     // intake.setDefaultCommand(new IntakeHold());
     // arm.setDefaultCommand(armMove);
@@ -190,4 +201,12 @@ public class RobotContainer {
   //     }
   //   }
   // }
+  /**
+   * Called when the alliance reported by the driverstation/FMS changes.
+   * @param alliance new alliance value
+   */
+  public void onAllianceChanged(Alliance alliance) {
+    poseEstimator.setAlliance(alliance);
+  }
+
 }

--- a/src/main/java/frc/robot/subsystems/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/Drivetrain.java
@@ -327,4 +327,7 @@ public class Drivetrain extends SubsystemBase {
   public SwerveModule getleftBack () {
     return leftBack;
   }
+  public Rotation2d getGyroscopeRotation() {
+    return gyro.getRotation2d();
+  }
 }

--- a/src/main/java/frc/robot/subsystems/PhotonRunnable.java
+++ b/src/main/java/frc/robot/subsystems/PhotonRunnable.java
@@ -1,0 +1,77 @@
+package frc.robot.subsystems;
+
+import static frc.robot.Constants.VisionConstants.APRILTAG_AMBIGUITY_THRESHOLD;
+import static frc.robot.Constants.VisionConstants.APRILTAG_CAMERA_TO_ROBOT;
+import static frc.robot.Constants.VisionConstants.FIELD_LENGTH_METERS;
+import static frc.robot.Constants.VisionConstants.FIELD_WIDTH_METERS;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.photonvision.EstimatedRobotPose;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonPoseEstimator;
+import org.photonvision.PhotonPoseEstimator.PoseStrategy;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.RobotState;
+
+/**
+ * Runnable that gets AprilTag data from PhotonVision.
+ */
+public class PhotonRunnable implements Runnable {
+
+  private final PhotonPoseEstimator photonPoseEstimator;
+  private final PhotonCamera photonCamera;
+  private final AtomicReference<EstimatedRobotPose> atomicEstimatedRobotPose = new AtomicReference<EstimatedRobotPose>();
+
+  public PhotonRunnable() {
+    this.photonCamera = new PhotonCamera("Arducam_OV9281_USB_Camera");
+    PhotonPoseEstimator photonPoseEstimator = null;
+    try {
+      var layout = AprilTagFields.k2023ChargedUp.loadAprilTagLayoutField();
+      // PV estimates will always be blue, they'll get flipped by robot thread
+      layout.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
+      if (photonCamera != null) {
+        photonPoseEstimator = new PhotonPoseEstimator(
+            layout, PoseStrategy.MULTI_TAG_PNP, photonCamera, APRILTAG_CAMERA_TO_ROBOT.inverse());
+      }
+    } catch(IOException e) {
+      DriverStation.reportError("Failed to load AprilTagFieldLayout", e.getStackTrace());
+      photonPoseEstimator = null;
+    }
+    this.photonPoseEstimator = photonPoseEstimator;
+  }
+
+  @Override
+  public void run() {      
+    // Get AprilTag data
+    if (photonPoseEstimator != null && photonCamera != null && !RobotState.isAutonomous()) {
+      var photonResults = photonCamera.getLatestResult();
+      if (photonResults.hasTargets() 
+          && (photonResults.targets.size() > 1 || photonResults.targets.get(0).getPoseAmbiguity() < APRILTAG_AMBIGUITY_THRESHOLD)) {
+        photonPoseEstimator.update(photonResults).ifPresent(estimatedRobotPose -> {
+          var estimatedPose = estimatedRobotPose.estimatedPose;
+          // Make sure the measurement is on the field
+          if (estimatedPose.getX() > 0.0 && estimatedPose.getX() <= FIELD_LENGTH_METERS
+              && estimatedPose.getY() > 0.0 && estimatedPose.getY() <= FIELD_WIDTH_METERS) {
+            atomicEstimatedRobotPose.set(estimatedRobotPose);
+          }
+        });
+      }
+    }  
+  }
+
+  /**
+   * Gets the latest robot pose. Calling this will only return the pose once. If it returns a non-null value, it is a
+   * new estimate that hasn't been returned before.
+   * This pose will always be for the BLUE alliance. It must be flipped if the current alliance is RED.
+   * @return latest estimated pose
+   */
+  public EstimatedRobotPose grabLatestEstimatedPose() {
+    return atomicEstimatedRobotPose.getAndSet(null);
+  }
+
+}

--- a/src/main/java/frc/robot/subsystems/PoseEstimatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/PoseEstimatorSubsystem.java
@@ -1,0 +1,174 @@
+package frc.robot.subsystems;
+
+import static edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition.kBlueAllianceWallRightSide;
+import static edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition.kRedAllianceWallRightSide;
+
+import java.util.function.Supplier;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
+import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.Vector;
+import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.Notifier;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.SwerveConstants;;
+import frc.robot.Constants.VisionConstants;
+
+/**
+ * Pose estimator that uses odometry and AprilTags with PhotonVision.
+ */
+public class PoseEstimatorSubsystem extends SubsystemBase {
+
+  // Kalman Filter Configuration. These can be "tuned-to-taste" based on how much
+  // you trust your various sensors. Smaller numbers will cause the filter to
+  // "trust" the estimate from that particular component more than the others. 
+  // This in turn means the particualr component will have a stronger influence
+  // on the final pose estimate.
+
+  /**
+   * Standard deviations of model states. Increase these numbers to trust your model's state estimates less. This
+   * matrix is in the form [x, y, theta]ᵀ, with units in meters and radians, then meters.
+   */
+  private static final Vector<N3> stateStdDevs = VecBuilder.fill(0.1, 0.1, 0.1);
+
+  /**
+   * Standard deviations of the vision measurements. Increase these numbers to trust global measurements from vision
+   * less. This matrix is in the form [x, y, theta]ᵀ, with units in meters and radians.
+   */
+  private static final Vector<N3> visionMeasurementStdDevs = VecBuilder.fill(1.5, 1.5, 1.5);
+
+  private final Supplier<Rotation2d> rotationSupplier;
+  private final Supplier<SwerveModulePosition[]> modulePositionSupplier;
+  private final SwerveDrivePoseEstimator poseEstimator;
+  private final Field2d field2d = new Field2d();
+  private final PhotonRunnable photonEstimator = new PhotonRunnable();
+  private final Notifier photonNotifier = new Notifier(photonEstimator);
+
+  private OriginPosition originPosition = kBlueAllianceWallRightSide;
+  private boolean sawTag = false;
+
+  public PoseEstimatorSubsystem(
+      Supplier<Rotation2d> rotationSupplier, Supplier<SwerveModulePosition[]> modulePositionSupplier) {
+    
+    this.rotationSupplier = rotationSupplier;
+    this.modulePositionSupplier = modulePositionSupplier;
+
+    poseEstimator =  new SwerveDrivePoseEstimator(
+        SwerveConstants.DRIVE_KINEMATICS,
+        rotationSupplier.get(),
+        modulePositionSupplier.get(),
+        new Pose2d(),
+        stateStdDevs,
+        visionMeasurementStdDevs);
+    
+    // Start PhotonVision thread
+    photonNotifier.setName("PhotonRunnable");
+    photonNotifier.startPeriodic(0.02);
+  }
+
+  public void addDashboardWidgets(ShuffleboardTab tab) {
+    tab.add("Field", field2d).withPosition(0, 0).withSize(6, 4);
+    tab.addString("Pose", this::getFomattedPose).withPosition(6, 2).withSize(2, 1);
+  }
+
+  /**
+   * Sets the alliance. This is used to configure the origin of the AprilTag map
+   * @param alliance alliance
+   */
+  public void setAlliance(Alliance alliance) {
+    boolean allianceChanged = false;
+    switch(alliance) {
+      case Blue:
+        allianceChanged = (originPosition == kRedAllianceWallRightSide);
+        originPosition = kBlueAllianceWallRightSide;
+        break;
+      case Red:
+        allianceChanged = (originPosition == kBlueAllianceWallRightSide);
+        originPosition = kRedAllianceWallRightSide;
+        break;
+      default:
+        // No valid alliance data. Nothing we can do about it
+    }
+
+    if (allianceChanged && sawTag) {
+      // The alliance changed, which changes the coordinate system.
+      // Since a tag was seen, and the tags are all relative to the coordinate system, the estimated pose
+      // needs to be transformed to the new coordinate system.
+      var newPose = flipAlliance(getCurrentPose());
+      poseEstimator.resetPosition(rotationSupplier.get(), modulePositionSupplier.get(), newPose);
+    }
+  }
+
+  @Override
+  public void periodic() {
+    // Update pose estimator with drivetrain sensors
+    poseEstimator.update(rotationSupplier.get(), modulePositionSupplier.get());
+
+    var visionPose = photonEstimator.grabLatestEstimatedPose();
+    if (visionPose != null) {
+      // New pose from vision
+      sawTag = true;
+      var pose2d = visionPose.estimatedPose.toPose2d();
+      if (originPosition != kBlueAllianceWallRightSide) {
+        pose2d = flipAlliance(pose2d);
+      }
+      poseEstimator.addVisionMeasurement(pose2d, visionPose.timestampSeconds);
+    }
+
+    // Set the pose on the dashboard
+    var dashboardPose = poseEstimator.getEstimatedPosition();
+    if (originPosition == kRedAllianceWallRightSide) {
+      // Flip the pose when red, since the dashboard field photo cannot be rotated
+      dashboardPose = flipAlliance(dashboardPose);
+    }
+    field2d.setRobotPose(dashboardPose);
+  }
+
+  private String getFomattedPose() {
+    var pose = getCurrentPose();
+    return String.format("(%.3f, %.3f) %.2f degrees", 
+        pose.getX(), 
+        pose.getY(),
+        pose.getRotation().getDegrees());
+  }
+
+  public Pose2d getCurrentPose() {
+    return poseEstimator.getEstimatedPosition();
+  }
+
+  /**
+   * Resets the current pose to the specified pose. This should ONLY be called
+   * when the robot's position on the field is known, like at the beginning of
+   * a match.
+   * @param newPose new pose
+   */
+  public void setCurrentPose(Pose2d newPose) {
+    poseEstimator.resetPosition(rotationSupplier.get(), modulePositionSupplier.get(), newPose);
+  }
+
+  /**
+   * Resets the position on the field to 0,0 0-degrees, with forward being downfield. This resets
+   * what "forward" is for field oriented driving.
+   */
+  public void resetFieldPosition() {
+    setCurrentPose(new Pose2d());
+  }
+
+  /**
+   * Transforms a pose to the opposite alliance's coordinate system. (0,0) is always on the right corner of your
+   * alliance wall, so for 2023, the field elements are at different coordinates for each alliance.
+   * @param poseToFlip pose to transform to the other alliance
+   * @return pose relative to the other alliance's coordinate system
+   */
+  private Pose2d flipAlliance(Pose2d poseToFlip) {
+    return poseToFlip.relativeTo(VisionConstants.FLIPPING_POSE);
+  }
+
+}

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,0 +1,41 @@
+{
+    "fileName": "photonlib.json",
+    "name": "photonlib",
+    "version": "v2023.4.2",
+    "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004 ",
+    "mavenUrls": [
+        "https://maven.photonvision.org/repository/internal",
+        "https://maven.photonvision.org/repository/snapshots"
+    ],
+    "jsonUrl": "https://maven.photonvision.org/repository/internal/org/photonvision/PhotonLib-json/1.0/PhotonLib-json-1.0.json",
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-cpp",
+            "version": "v2023.4.2",
+            "libName": "Photon",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "linuxathena",
+                "linuxx86-64",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "javaDependencies": [
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonLib-java",
+            "version": "v2023.4.2"
+        },
+        {
+            "groupId": "org.photonvision",
+            "artifactId": "PhotonTargeting-java",
+            "version": "v2023.4.2"
+        }
+    ]
+}


### PR DESCRIPTION
I have merged the PhotonRunnable and PoseEstimator subsystems from [FRC7028](https://github.com/STMARobotics/frc-7028-2023)  into main.   The current code should create a vision tab and use the AprilTags to compute the position of the robot and post the position on the field.   In the future we could use the field position for readouts when picking up cones from the shelf, scoring, and in autonomous.   I have not tested this code and I don't want to distract from autonomous or any other changes.
